### PR TITLE
Removed IsThanosEnabled check

### DIFF
--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -479,22 +479,6 @@ func GetETLMaxPrometheusQueryDuration() time.Duration {
 	return mins * time.Minute
 }
 
-// GetETLResolution determines the resolution of ETL queries. The smaller the
-// duration, the higher the resolution; the higher the resolution, the more
-// accurate the query results, but the more computationally expensive. This
-// value is always 1m for Prometheus, but is configurable for Thanos.
-func GetETLResolution() time.Duration {
-	// If Thanos is not enabled, hard-code to 1m resolution
-	if !IsThanosEnabled() {
-		return 60 * time.Second
-	}
-
-	// Thanos is enabled, so use the configured ETL resolution, or default to
-	// 5m (i.e. 300s)
-	secs := time.Duration(GetInt64(ETLResolutionSeconds, 300))
-	return secs * time.Second
-}
-
 func LegacyExternalCostsAPIDisabled() bool {
 	return GetBool(LegacyExternalAPIDisabledVar, false)
 }


### PR DESCRIPTION
Removed 'IsThanosEnabled' check as it is not required and possibly causing issues for some users.

## What does this PR change?
* It removes code that checks if thanos is enabled, and if not sets `ETLResolutionSeconds` to 1 min. 

## Does this PR address any GitHub or Zendesk issues?
* https://kubecost.zendesk.com/agent/tickets/3246

## How was this PR tested?
* It was not tested
